### PR TITLE
Add Server.socket property.

### DIFF
--- a/bjsonrpc/server.py
+++ b/bjsonrpc/server.py
@@ -182,3 +182,9 @@ class Server(object):
             except Exception:
                 pass
 
+    @property
+    def socket(self): 
+        """
+            public property that holds the internal listener socket used.
+        """
+        return self._lstsck


### PR DESCRIPTION
This is useful for binding a service to port 0 and then finding out what port it actually got:

```
s = bjsonrpc.createserver(port=0, handler_factory=MyHandler)
port = s.socket.getsockname()[1]
```

Connection already has a similar property.
