### PR TITLE
Port from python 2.5-2.7 to 2.6-2.7/3.2+.

### DIFF
--- a/bjsonrpc/handlers.py
+++ b/bjsonrpc/handlers.py
@@ -147,16 +147,16 @@ class BaseHandler(object):
             try:
                 assert(method.__name__ not in self._methods)
             except AssertionError:
-                raise NameError, "Method with name %s already in the class methods!" % (method.__name__)
+                raise NameError("Method with name %s already in the class methods!" % (method.__name__))
             self._methods[method.__name__] = method
             
-        for name, method in kwargs.iteritems():
+        for name, method in kwargs.items():
             if method.__name__ in self.nonpublic_methods: 
                 continue
             try:
                 assert(name not in self._methods)
             except AssertionError:
-                raise NameError, "Method with name %s already in the class methods!" % (method.__name__)
+                raise NameError("Method with name %s already in the class methods!" % (method.__name__))
                 
             self._methods[name] = method
 

--- a/bjsonrpc/jsonlib.py
+++ b/bjsonrpc/jsonlib.py
@@ -36,7 +36,7 @@ try:
 except ImportError:
     import json as j
 except ImportError:
-    print "FATAL: No suitable json library found!"
+    print("FATAL: No suitable json library found!")
     raise
 from pprint import pprint
 

--- a/bjsonrpc/request.py
+++ b/bjsonrpc/request.py
@@ -32,7 +32,10 @@
 
 """
 
-import Queue
+try:
+    from Queue import Queue
+except ImportError:
+    from queue import Queue
 import logging
 from threading import Event
 import traceback
@@ -84,7 +87,7 @@ class Request(object):
     def __init__(self, conn, request_data):
         self.conn = conn
         self.data = request_data
-        self.responses = Queue.Queue()
+        self.responses = Queue()
         # TODO: Now that we have a Queue, do we need an Event (and a cv)?
         self.event_response = Event()
         self.callbacks = []
@@ -125,7 +128,7 @@ class Request(object):
         for callback in self.callbacks: 
             try:
                 callback(self)
-            except Exception, exc:
+            except Exception as exc:
                 _log.error("Error on callback: %r", exc)
                 _log.debug(traceback.format_exc())
                 
@@ -150,8 +153,11 @@ class Request(object):
     def __iter__(self):
         return self
 
-    def next(self):
+    def __next__(self):
         return self.value
+
+    def next(self):
+        return self.__next__()
 
     def close(self):
         reqid, self.request_id, self.auto_close = self.request_id, None, False

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -6,7 +6,6 @@ from bjsonrpc.exceptions import ServerError
 
 import testserver1
 import math
-from types import ListType
 
 class TestJSONBasics(unittest.TestCase):
     def setUp(self):
@@ -105,7 +104,7 @@ class TestJSONBasics(unittest.TestCase):
         """
         rcall = self.conn.call 
         result = rcall.getabc()
-        self.assertTrue(isinstance(result, ListType),"JSON library should convert tuples to lists!")
+        self.assertTrue(isinstance(result, list),"JSON library should convert tuples to lists!")
         
         
     def test_kwparams(self):


### PR DESCRIPTION
**NOTE: Breaks 2.5 compatibility!**
- Besides the trivial syntax changes, this required changing the
  Connection.write_line loop to keep _wbuffer as a flat bytes string
  instead of a list of strings. (Since it was already flattening each
  string and then exploding it into a list of 1-char strings, there's
  no performance downside to thsi change.)
- As a side-effect of the changes, Connection.write and friends can
  now handle either bytes or unicode strings. Since the high-level
  methods are all in terms of JSON objects, this only really makes a
  difference for debugging bjsonrpc itself. (The json module will
  only give us str objects--bytes on 2.x, unicode on 3.x--and any
  non-ASCII characters will already be escaped for JSON anyway.)
