### PR TITLE
Check for EWOULDBLOCK as well as EAGAIN.

### DIFF
--- a/bjsonrpc/connection.py
+++ b/bjsonrpc/connection.py
@@ -854,7 +854,7 @@ class Connection(object): # TODO: Split this class in simple ones
             except IOError as inst:
                 _log.debug("Read socket error: IOError%r (timeout: %r)",
                     inst.args, self._sck.gettimeout())
-                if inst.errno == errno.EAGAIN:
+                if inst.errno in (errno.EAGAIN, errno.EWOULDBLOCK):
                     if self._sck.gettimeout() == 0: # if it was too fast
                         self._sck.settimeout(5)
                         continue


### PR DESCRIPTION
- POSIX allows recv to return either `EAGAIN` or `EWOULDBLOCK`, and
  allows them to be the same value. On nearly every modern POSIX
  system, it returns `EAGAIN`, and they are the same value. But
  Winsock returns `EWOULDBLOCK`, and defines them as different
  values. So, we need to check both, not just `EAGAIN`.
- See http://pubs.opengroup.org/onlinepubs/009695399/functions/recv.html for POSIX spec, http://msdn.microsoft.com/en-us/library/windows/desktop/ms740121(v=vs.85).aspx for MSDN.
