### PR TITLE
Don't respond if request id is None or absent

### DIFF
--- a/bjsonrpc/connection.py
+++ b/bjsonrpc/connection.py
@@ -590,12 +590,12 @@ class Connection(object): # TODO: Split this class in simple ones
             raise
 
     def _send_response(self, item, response):
-        if item['id']:
+        if item.get('id') is not None:
             ret = { 'result': response, 'error': None, 'id': item['id'] }
             self._send(ret)
 
     def _send_error(self, item, err):
-        if item['id']:
+        if item.get('id') is not None:
             ret = { 'result': None, 'error': err, 'id': item['id'] }
             self._send(ret)
 


### PR DESCRIPTION
Requests without id are valid (notifications, as per http://www.jsonrpc.org/specification#request_object).

Also, 0 is a valid request id. Check for that.
