### PR TITLE
Basic support for rpc over HTTP.

### DIFF
--- a/bjsonrpc/main.py
+++ b/bjsonrpc/main.py
@@ -21,7 +21,8 @@ __all__ = [
 ]
 
 def createserver(host="127.0.0.1", port=10123, 
-    handler_factory=bjsonrpc.handlers.NullHandler):
+    handler_factory=bjsonrpc.handlers.NullHandler,
+    http=False):
     """
         Creates a *bjson.server.Server* object linked to a listening socket.
         
@@ -56,7 +57,7 @@ def createserver(host="127.0.0.1", port=10123,
 
     sck.bind((host, port))
     sck.listen(3) 
-    return bjsonrpc.server.Server(sck, handler_factory=handler_factory)
+    return bjsonrpc.server.Server(sck, handler_factory=handler_factory, http=http)
         
         
 def connect(host="127.0.0.1", port=10123, 

--- a/bjsonrpc/server.py
+++ b/bjsonrpc/server.py
@@ -56,12 +56,13 @@ class Server(object):
             connections. Should be an inherited class of *bjsonrpc.handlers.BaseHandler*
             
     """
-    def __init__(self, lstsck, handler_factory):
+    def __init__(self, lstsck, handler_factory, http):
         self._lstsck = lstsck
         self._handler = handler_factory
         self._debug_socket = False
         self._debug_dispatch = False
         self._serve = True
+        self._http = http
     
     def stop(self):
         """
@@ -146,7 +147,8 @@ class Server(object):
             
                     conn = Connection(
                             sck = clientsck, address = clientaddr, 
-                            handler_factory = self._handler
+                            handler_factory = self._handler,
+                            http = self._http
                             )
                     connidx[clientsck.fileno()] = conn
                     conn._debug_socket = self._debug_socket


### PR DESCRIPTION
An extra 'http' flag is allowed on createserver which signals that the server accepts HTTP data over its socket instead of raw json lines, which is useful to allow, for example, javascript functions to POST calls.
There is no real HTTP layer error checking, which should be added.
The client side hasn't been changed to support HTTP.
