### PR TITLE
Clean the circular reference between Connection and BaseHandler

### DIFF
--- a/bjsonrpc/handlers.py
+++ b/bjsonrpc/handlers.py
@@ -127,7 +127,7 @@ class BaseHandler(object):
             You should add cleanup code here. Remember to call the parent
             function.
         """
-        pass # In the future, here we could have some internal clean-up code.
+        self.close()
         
     def close(self):
         """
@@ -135,6 +135,7 @@ class BaseHandler(object):
             manually from connection whenever a handler is going to be deleted.
         """
         self._methods = {}
+        self._conn = None
 
     def add_method(self, *args, **kwargs):
         """


### PR DESCRIPTION
This circular reference prevents `Connection` objects from being properly freed, creating a leak. This fixes it.

Also, `BaseHandler.close()` is never called, so the call is made in `BaseHandler._shutdown()`, which is called by `Connection.close()`