### PR TITLE
JSONRPC 2.0 sends either 'result' or 'error'. Test for both.

### DIFF
--- a/bjsonrpc/connection.py
+++ b/bjsonrpc/connection.py
@@ -571,7 +571,7 @@ class Connection(object): # TODO: Split this class in simple ones
                     for i in item: 
                         dispatch_item(i)
                 elif type(item) is dict: # std call
-                    if 'result' in item:
+                    if 'result' in item or 'error' in item:
                         self.dispatch_item_single(item)
                     else:
                         dispatch_item(item)
@@ -653,7 +653,7 @@ class Connection(object): # TODO: Split this class in simple ones
                 err = self._format_exception(obj, method, args, kw,
                                              sys.exc_info())
                 self._send_error(item, err)
-        elif 'result' in item:
+        elif 'result' in item or 'error' in item:
             assert(item['id'] in self._requests)
             request = self._requests[item['id']]
             request.setresponse(item)


### PR DESCRIPTION
This makes bjsonrpc (in client mode) able to properly process error messages from java/jsonrpc4j, which speaks JSONRPC 2.0.

Depends on changing jsonrpc4j code to include a newline with every reply, PR opened at https://github.com/briandilley/jsonrpc4j/pull/61.
